### PR TITLE
쓸모 없는 autojoin 코드 제거 & 호스팅은 빠른 것 & PUN 로그 레벨 높임

### DIFF
--- a/Assets/02.Scripts/ServerInit.cs
+++ b/Assets/02.Scripts/ServerInit.cs
@@ -18,7 +18,6 @@ public class ServerInit : MonoBehaviour {
 
 	void Awake () {
 		if (!PhotonNetwork.connected) {
-			PhotonNetwork.autoJoinLobby = true;
 			PhotonNetwork.ConnectUsingSettings (version);
 		}
 

--- a/Assets/Photon Unity Networking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon Unity Networking/Resources/PhotonServerSettings.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   AppID: 195f618f-89d4-4c05-88ce-44d4c6087340
   VoiceAppID: 
   ChatAppID: 
-  HostType: 1
+  HostType: 4
   PreferredRegion: 9
   EnabledRegions: -1
   Protocol: 0
@@ -23,7 +23,7 @@ MonoBehaviour:
   VoiceServerPort: 5055
   JoinLobby: 1
   EnableLobbyStatistics: 0
-  PunLogging: 0
+  PunLogging: 2
   NetworkLogging: 1
   RunInBackground: 1
   RpcList:


### PR DESCRIPTION
1. autojoin은 punsetting에서 이미 설정되어 있으므로 필요없는 코드.
2. 호스팅은 best region을 알아서 찾도록 함.
3. pun에 관련된 로그 레벨을 모두 표시하도록 설정.